### PR TITLE
feat(#39): Adding attendee via an API

### DIFF
--- a/apps/admin/app/api/attendee/add/[conventionId]/route.ts
+++ b/apps/admin/app/api/attendee/add/[conventionId]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server"
+import prisma from "@/app/lib/prisma";
+import { DateTime } from "ts-luxon";
+import { IAddAttendeeRequest } from "@/app/api/requests/add-attendee-request";
+
+
+// https://stackoverflow.com/questions/73839916/how-to-run-functions-that-take-more-than-10s-on-vercel
+// https://vercel.com/docs/functions/runtimes#max-execution-time
+export const maxDuration = 10; // 10 seconds
+
+export async function POST(request: NextRequest, { params }: { params: { conventionId: string }}) {
+  const attendeeToAdd: IAddAttendeeRequest = await request.json();
+  let personId: number = -1
+
+  //1. Ensure convention id exists
+  const conventionExists = await prisma.convention.count({
+    where: { id: Number(params.conventionId)}
+  })
+
+  if (conventionExists <= 0) return NextResponse.json({ message: 'Unable to find convention that you are trying to add the Attendee for'}, { status: 400 })
+
+  // 2. Try to find person in the system the best we can...
+  const isPersonInSystem = await prisma.person.findFirst({
+    where: {
+      OR: [
+        { email: attendeeToAdd.email },
+        { phoneNumber: attendeeToAdd.phoneNumber },
+        { 
+          firstName: attendeeToAdd.preferredName || attendeeToAdd.firstName,
+          lastName: attendeeToAdd.lastName,
+        },
+        {
+          firstName: attendeeToAdd.firstName,
+          preferredName: attendeeToAdd.preferredName,
+          lastName: attendeeToAdd.lastName,
+        },
+      ]
+    }
+  })
+
+  // 3. Upsert a new person into the system
+  const person = await prisma.person.upsert({
+    where: {
+      id: isPersonInSystem ? isPersonInSystem.id : undefined, // Use existing id if available
+    },
+    update: {
+      // Merge existing data with provided data
+      firstName: attendeeToAdd.firstName || isPersonInSystem?.firstName,
+      preferredName: attendeeToAdd.preferredName || isPersonInSystem?.preferredName,
+      lastName: attendeeToAdd.lastName || isPersonInSystem?.lastName,
+      email: attendeeToAdd.email || isPersonInSystem?.email,
+      phoneNumber: attendeeToAdd.phoneNumber || isPersonInSystem?.phoneNumber,
+    },
+    create: {
+      // Use only the provided data if no existing record found
+      firstName: attendeeToAdd.firstName,
+      preferredName: attendeeToAdd.preferredName,
+      lastName: attendeeToAdd.lastName,
+      email: attendeeToAdd.email || null,
+      phoneNumber: attendeeToAdd.phoneNumber || null,
+    },
+  })
+
+  // 4. Add a new barcode for the attendee
+  try {
+    // Create new barcode
+    const barcodeAdded = await prisma.centralizedBarcode.create({
+      data: {
+        entityId: 0,
+        entityType: "Attendee",
+        barcode: attendeeToAdd.barcode,
+      },
+    })
+
+    // 5. Add new attendee after barcode was completed
+    const newAttendee = await prisma.attendee.create({
+      data: {
+        barcode: attendeeToAdd.barcode,
+        conventionId: Number(params.conventionId),
+        personId: person.id,
+        dateRegistered: DateTime.utc().toISO()
+      }
+    })
+
+    // 6. Update barcode with correct entity id
+    await prisma.centralizedBarcode.update({
+      where: { id: barcodeAdded.id },
+      data: { 
+        entityId: newAttendee.id
+      }
+    })
+
+  } catch (error) {
+    return NextResponse.json({
+      message: 'Failed to add attendee as the barcode was already in the system',
+      error: error
+    }, { status: 515 })
+  }
+
+  return NextResponse.json(
+    {
+      message: "Successfully added attendee to conference",
+    },
+    { status: 201 }
+  );
+
+}

--- a/apps/admin/app/api/requests/add-attendee-request.ts
+++ b/apps/admin/app/api/requests/add-attendee-request.ts
@@ -1,0 +1,11 @@
+interface IAddAttendeeRequest {
+  barcode: string
+  firstName: string
+  preferredName?: string
+  lastName: string
+  phoneNumber?: string
+  email?: string
+  isStayingAtConvention: Boolean
+}
+
+export type { IAddAttendeeRequest }

--- a/packages/tgd-database/prisma/docs/schema.dbml
+++ b/packages/tgd-database/prisma/docs/schema.dbml
@@ -118,6 +118,10 @@ Table people {
   email String
   phoneNumber String
   attendee attendees [not null]
+
+  indexes {
+    (firstName, lastName) [unique]
+  }
 }
 
 Table play_to_win_items {
@@ -168,9 +172,12 @@ Table attendees {
   barcode String [not null]
   person people [not null]
   isCheckedIn Boolean [not null, default: false]
+  hasCancelled Boolean [not null, default: false]
+  isStayingOnSite Boolean [not null, default: false]
   conventionId Int [not null]
   convention conventions [not null]
   checkedInUtc String
+  dateRegistered String [not null]
   isVolunteer Boolean [not null, default: false]
   idTgdOrganizer Boolean [not null, default: false]
   centralizedBarcode centralized_barcodes [not null]

--- a/packages/tgd-database/prisma/lib/save-data.ts
+++ b/packages/tgd-database/prisma/lib/save-data.ts
@@ -179,7 +179,7 @@ function DetermineGameOwner(barcode: string) {
   if (barcode.toUpperCase().includes("RR")) {
     return "Russ Rupe";
   } else if (barcode.toUpperCase().includes("RK")) {
-    return "Richard Keuler";
+    return "Rick Keuler";
   } else if (barcode.toUpperCase().includes("GP")) {
     return "Game Point";
   } else {

--- a/packages/tgd-database/prisma/migrations/20240327222617_39_person_constraint/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240327222617_39_person_constraint/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[first_name,last_name]` on the table `people` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "attendees" ADD COLUMN     "has_cancelled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "staying_at_convention" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "people_first_name_last_name_key" ON "people"("first_name", "last_name");

--- a/packages/tgd-database/prisma/migrations/20240327225643_39_registered_time/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240327225643_39_registered_time/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `registered_date_utc` to the `attendees` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "attendees" ADD COLUMN     "registered_date_utc" TEXT NOT NULL;

--- a/packages/tgd-database/prisma/schema.prisma
+++ b/packages/tgd-database/prisma/schema.prisma
@@ -167,6 +167,7 @@ model Person {
   phoneNumber   String?    @map(name: "phone_number")
   attendee      Attendee[]
 
+  @@unique([firstName, lastName])
   @@map("people")
 }
 
@@ -225,16 +226,19 @@ model PlayToWinPlayAttendee {
 }
 
 model Attendee {
-  id             Int        @id @default(autoincrement()) @map(name: "id")
-  personId       Int        @map(name: "person_id")
-  barcode        String     @map(name: "barcode")
-  person         Person     @relation(fields: [personId], references: [id])
-  isCheckedIn    Boolean    @default(false) @map(name: "is_checked_in")
-  conventionId   Int        @map(name: "convention_id")
-  convention     Convention @relation(fields: [conventionId], references: [id])
-  checkedInUtc   String?    @map(name: "checked_in_utc")
-  isVolunteer    Boolean    @default(false) @map(name: "is_volunteer")
-  idTgdOrganizer Boolean    @default(false) @map(name: "is_organizer")
+  id              Int        @id @default(autoincrement()) @map(name: "id")
+  personId        Int        @map(name: "person_id")
+  barcode         String     @map(name: "barcode")
+  person          Person     @relation(fields: [personId], references: [id])
+  isCheckedIn     Boolean    @default(false) @map(name: "is_checked_in")
+  hasCancelled    Boolean    @default(false) @map(name: "has_cancelled")
+  isStayingOnSite Boolean    @default(false) @map(name: "staying_at_convention")
+  conventionId    Int        @map(name: "convention_id")
+  convention      Convention @relation(fields: [conventionId], references: [id])
+  checkedInUtc    String?    @map(name: "checked_in_utc")
+  dateRegistered  String     @map(name: "registered_date_utc")
+  isVolunteer     Boolean    @default(false) @map(name: "is_volunteer")
+  idTgdOrganizer  Boolean    @default(false) @map(name: "is_organizer")
 
   centralizedBarcode CentralizedBarcode    @relation(fields: [barcode], references: [barcode])
   checkOutEvents     LibraryCheckoutEvent[]


### PR DESCRIPTION
## Completed

- Add API for getting attendees one at a time

refs: #39

## Items to discuss with Russ

- [ ] Do we want the system to generate the barcodes - if yes we can do (Year-AttendeeRowNumber)
- [ ] Do we want the system to import via CSV file or plug into the tennesseegamedays website
- [ ] Do I want to support upping the convention id every time or having another API that gets the proper convention id for the next upcoming convention?
- [ ] How do we want to handle cancellations?
- [ ] Do we want a list of all attendees for the upcoming convention?

Create Features and Bugs based on the checkboxes above