### PR TITLE
feat(#38): Add library reporting

### DIFF
--- a/apps/admin/app/api/library/check-in/[libraryId]/route.ts
+++ b/apps/admin/app/api/library/check-in/[libraryId]/route.ts
@@ -36,7 +36,7 @@ export async function PUT(request: NextRequest, { params }: { params: { libraryI
       data: {
         isCheckedOut: false,
         totalCheckedOutMinutes: {
-          increment: Number(checkedInTime.diff(DateTime.fromISO(result.checkedOutTimeUtcIso), 'minutes').toObject().minutes?.toFixed(0))
+          increment: Number(checkedInTime.diff(DateTime.fromJSDate(result.checkedOutTimeUtcIso), 'minutes').toObject().minutes?.toFixed(0))
         }
       }
     })

--- a/apps/admin/app/api/library/check-out/route.ts
+++ b/apps/admin/app/api/library/check-out/route.ts
@@ -30,6 +30,25 @@ export async function POST(request: NextRequest) {
   if (hasGameCheckedOut !== 0) return NextResponse.json({ message: 'User has game already checked out!'}, { status: 420 })  
   if (libraryItem.isCheckedOut) return NextResponse.json({ message: "Game already checked out!" }, { status: 400 })
 
+  const currentConvention = await prisma.convention.findFirst({
+    where: {
+      AND: [
+        {
+          startDateTimeUtc: {
+            gte: DateTime.utc().toISO()
+          }
+        },
+        {
+          endDateTimeUtc: {
+            lte: DateTime.utc().toISO()
+          }
+        }
+      ]
+    }
+  })
+
+  console.log("convention", currentConvention)
+
   await prisma.$transaction(async t => {
 
     await t.libraryItem.update({

--- a/apps/admin/app/api/library/stats/all-time-top-20/route.ts
+++ b/apps/admin/app/api/library/stats/all-time-top-20/route.ts
@@ -6,36 +6,59 @@ export const revalidate = 0; //Very important
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
+interface Top20CheckedOutGameDto {
+  bgg_id: string
+  total_checkout_minutes: bigint
+  total_checkout_events: number
+  library_item_name: string
+  bgg_average_rating: number
+  bgg_average_complexity: number
+  playing_time_min: number
+  min_player_count: number
+  max_player_count: number
+  all_copies_checked_out: boolean
+}
+
 export async function GET() {
-  const top20CheckedOutGames = await prisma.libraryItem.findMany({
-    where: {
-      totalCheckedOutMinutes: {
-        gt: 0 // greater than 0
-      }
-    },
-    select: {
-      id: true,
-      alias: true,
-      barcode: true,
-      totalCheckedOutMinutes: true,
-      boardGameGeekId: true,
-      isCheckedOut: true,
-      boardGameGeekThing: true,
-      _count: { 
-        select: { 
-          checkOutEvents: true
-        }
-      }
-    },
-    orderBy: {
-      checkOutEvents: {
-        _count: 'desc'
-      }
-    },
-    take: 20 // limit to the top 20 results
-  });
+
+  //https://github.com/prisma/prisma/discussions/16255
+  // Only option for nested group by is to use raw query
+
+  const top20CheckedOutGames: Top20CheckedOutGameDto[] = await prisma.$queryRaw`
+    SELECT
+    l.bgg_id,
+    SUM(l.minutes_checked_out) AS total_checkout_minutes,
+    COUNT(*) AS total_checkout_events,
+    COALESCE(l.alias, b.bgg_item_name) AS library_item_name,
+    b.bgg_average_rating as bgg_average_rating,
+    b.bgg_weight_rating as bgg_average_complexity,
+    COUNT(*) = SUM(CASE WHEN l.is_checked_out = true THEN 1 ELSE 0 END) AS all_copies_checked_out,
+    b.playing_time_min,
+    b.min_player_count,
+    b.max_player_count
+    FROM public.library_checkout_events AS e
+    INNER JOIN public.library_items AS l ON l.id = e.library_item_id
+    INNER JOIN public.board_game_geek_items as b ON b.bgg_id = l.bgg_id
+    GROUP BY l.bgg_id, library_item_name, b.bgg_average_rating, b.bgg_weight_rating, b.playing_time_min, b.min_player_count, b.max_player_count
+    ORDER BY total_checkout_minutes DESC
+    LIMIT 20
+  `
+
+  // Convert BigInt values to strings
+  const formattedData = top20CheckedOutGames.map(entry => ({
+    bggId: entry.bgg_id,
+    libraryItemName: entry.library_item_name,
+    allCopiesCheckedOut: entry.all_copies_checked_out,
+    totalCheckedOutMinutes: entry.total_checkout_minutes.toString(),
+    totalCheckedOutEvents: entry.total_checkout_events.toString(),
+    bggAverageRating: entry.bgg_average_rating,
+    bggAverageComplexity: entry.bgg_average_complexity,
+    minPlayerCount: entry.min_player_count,
+    maxPlayerCount: entry.max_player_count,
+    bggPlaytimeMinutes: entry.playing_time_min
+  }));
 
   return NextResponse.json({
-    list: top20CheckedOutGames,
-  }, { status: 200 });
+    list: formattedData,
+  }, { status: 200 })
 }

--- a/apps/admin/app/api/play-to-win/log/route.ts
+++ b/apps/admin/app/api/play-to-win/log/route.ts
@@ -14,6 +14,7 @@ export async function POST(request: NextRequest) {
   if (data === undefined) return NextResponse.json({ error: 'Request is not correct, please verify your request'}, { status: 400 })
   if (data.attendeeIds === undefined || data.attendeeIds.length <= 0) return NextResponse.json({ error: 'No attendee Ids were linked and could not add the PTW play'}, { status: 400 })
 
+  // TODO: @WZ - Fix this to be during convention
   const nextUpcomingConvention = await prisma.convention.findFirst({
     where: {
       endDateTimeUtc: {

--- a/apps/admin/app/api/report/[conventionId]/library/route.ts
+++ b/apps/admin/app/api/report/[conventionId]/library/route.ts
@@ -1,0 +1,123 @@
+import prisma from "@/app/lib/prisma"
+import { NextRequest, NextResponse } from "next/server"
+import { DateTime } from "ts-luxon";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { conventionId: string } }
+) {
+
+  const conventionForReport = await prisma.convention.findFirst({
+    where: { id: Number(params.conventionId) }
+  })
+
+  if (conventionForReport === null) return NextResponse.json({ message: "Convention not found" }, { status: 404 })
+  if (!conventionForReport.startDateTimeUtc) return NextResponse.json({ message: "Convention start date was not found" }, { status: 522 })
+  if (!conventionForReport.endDateTimeUtc) return NextResponse.json({ message: "Convention end date was not found" }, { status: 522 })
+
+
+  const [gameCheckouts, gamesNotCheckedOut] = await Promise.all([
+    prisma.libraryItem.findMany({
+      where: {
+        AND: [
+          { 
+            checkOutEvents: {
+              some: {
+                checkedInTimeUtcIso: { lte: conventionForReport.endDateTimeUtc, not: null }
+              }
+            }
+          },
+          {
+            checkOutEvents: {
+              some: {
+                checkedOutTimeUtcIso: { gte: conventionForReport.startDateTimeUtc }
+              }
+            }
+          }
+        ]
+      },
+      select: {
+        _count: {
+          select: {
+            checkOutEvents: true
+          }
+        },
+        checkOutEvents: {
+          select: {
+            checkedOutTimeUtcIso: true,
+            checkedInTimeUtcIso: true,
+          }
+        },
+        totalCheckedOutMinutes: true,
+        alias: true,
+        owner: true,
+        barcode: true,
+        boardGameGeekThing: {
+          select: {
+            itemName: true
+          }
+        }
+      },
+      orderBy: {
+        checkOutEvents: {
+          _count: 'desc'
+        }
+      }
+    }),
+    prisma.libraryItem.findMany({
+      where: {
+        NOT: {
+          AND: [
+            { 
+              checkOutEvents: {
+                some: {
+                  checkedInTimeUtcIso: { lte: conventionForReport.endDateTimeUtc, not: null }
+                }
+              }
+            },
+            {
+              checkOutEvents: {
+                some: {
+                  checkedOutTimeUtcIso: { gte: conventionForReport.startDateTimeUtc }
+                }
+              }
+            }
+          ]
+        }
+      },
+      select: {
+        totalCheckedOutMinutes: true,
+        alias: true,
+        owner: true,
+        barcode: true,
+        boardGameGeekThing: {
+          select: {
+            itemName: true
+          }
+        }
+      },
+    })
+  ])
+
+  return NextResponse.json({ 
+    itemsPlayed: gameCheckouts.map(item => ({
+      barcode: item.barcode,
+      owner: item.owner,
+      timesCheckedOut: item._count.checkOutEvents,
+      name: item.alias ?? item.boardGameGeekThing?.itemName,
+      totalTimeCheckedOut: item.totalCheckedOutMinutes,
+      conferenceTimeCheckedOut: Number(item.checkOutEvents.reduce((acc, current) => {
+        if (current.checkedInTimeUtcIso === null) return acc
+        const minutesCheckedOut = DateTime.fromJSDate(current.checkedInTimeUtcIso).diff(DateTime.fromJSDate(current.checkedOutTimeUtcIso), 'minutes').minutes
+        return acc + minutesCheckedOut
+      }, 0).toFixed(0))
+    })),
+    itemsNotPlayed: gamesNotCheckedOut.map(item => ({
+      barcode: item.barcode,
+      owner: item.owner,
+      totalCheckedOutMinutes: item.totalCheckedOutMinutes,
+      name: item.alias ?? item.boardGameGeekThing?.itemName
+    })).sort((a, b) => a.name.localeCompare(b.name))
+}, { status: 200 });
+
+}

--- a/apps/admin/app/api/report/[conventionId]/play-to-win/route.ts
+++ b/apps/admin/app/api/report/[conventionId]/play-to-win/route.ts
@@ -1,5 +1,5 @@
-import prisma from "@/app/lib/prisma";
-import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/app/lib/prisma"
+import { NextRequest, NextResponse } from "next/server"
 
 export async function GET(
   request: NextRequest,
@@ -49,48 +49,3 @@ export async function GET(
   return NextResponse.json(result)
 
 }
-
-
-
-// id                 Int                 @id @default(autoincrement()) @map(name: "id")
-// barcode            String              @map(name: "barcode")
-// boardGameGeekId    Int?                @map(name: "bgg_id")
-// boardGameGeekThing BoardGameGeekThing? @relation(fields: [boardGameGeekId], references: [id])
-// gameName           String?             @map(name: "game_name")
-// conventionId       Int                 @map(name: "convention_id")
-// convention         Convention          @relation(fields: [conventionId], references: [id])
-// isHidden           Boolean             @map(name: "is_hidden")
-// totalTimesPlayed   Int                 @default(0) @map(name: "total_played")
-// publisherName      String?             @map(name: "publisher")
-// dateAddedUtc       String              @map(name: "date_added_utc")
-// centralizedBarcode CentralizedBarcode  @relation(fields: [barcode], references: [barcode])
-
-// playToWinPlays     PlayToWinPlay[]
-
-// // is_checked_out?
-// @@unique([barcode])
-// @@map("play_to_win_items")
-
-
-// model PlayToWinPlay {
-//   id                        String        @id @default(cuid()) @map(name: "id")
-//   playToWinItemId           Int           @map(name: "play_to_win_item_id")
-//   playToWinItem             PlayToWinItem @relation(fields: [playToWinItemId], references: [id])
-//   checkedInTimeUtcIso       String        @map("checked_in_time_utc")
-//   conventionId              Int           @map("convention_id")
-//   convention                Convention    @relation(fields: [conventionId], references: [id])
-
-//   playToWinPlayAttendees    PlayToWinPlayAttendee[]
-
-//   @@map("play_to_win_plays")
-// }
-
-// model PlayToWinPlayAttendee {
-//   id                        String        @id @default(cuid()) @map(name: "id")
-//   playToWinItemId           String        @map(name: "play_to_win_play_id")
-//   playToWinPlay             PlayToWinPlay @relation(fields: [playToWinItemId], references: [id])
-//   attendeeId                Int           @map(name: "attendee_id")
-//   attendee                  Attendee      @relation(fields: [attendeeId], references: [id])
-
-//   @@map("play_to_win_play_players")
-// }

--- a/apps/admin/app/components/top-20-results/results-table.tsx
+++ b/apps/admin/app/components/top-20-results/results-table.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { IBoardGameGeekEntity } from "@repo/board-game-geek-shared"
 import { TopCheckedOutGame } from "@repo/shared"
-import { useEffect, useState } from "react"
 
 interface TopCheckedOutGameProps {
   topCheckedOutGames: TopCheckedOutGame[]
@@ -55,6 +53,9 @@ function ResultsTableHeader(): JSX.Element {
         <th className="py-2 px-4 text-gray-500 hidden md:table-cell">
           Max Player count
         </th>
+        <th className="py-2 px-4 text-gray-500 hidden md:table-cell">
+          Playtime (min)
+        </th>
       </tr>
     </thead>
   )
@@ -70,7 +71,7 @@ function ResultsTableBody({ games }: ResultsTableBodyProps): JSX.Element {
     <tbody className="text-center">
 
       { games.map((game) => (
-        <ResultsTableRow key={game.barcode} {...game} checkOutCount={game._count.checkOutEvents} />
+        <ResultsTableRow key={game.bggId} {...game} />
       ))}
 
     </tbody>
@@ -78,28 +79,34 @@ function ResultsTableBody({ games }: ResultsTableBodyProps): JSX.Element {
 }
 
 interface ResultsRowProps {
-  alias: string
-  barcode: string
-  boardGameGeekThing: IBoardGameGeekEntity,
-  totalCheckedOutMinutes: number
-  checkOutCount: number
-  isCheckedOut: boolean
+  bggId: number
+  libraryItemName: string
+  allCopiesCheckedOut: boolean
+  totalCheckedOutMinutes: string // bigint needs to be string
+  totalCheckedOutEvents: string // bigint needs to be string
+  bggAverageRating: number
+  bggAverageComplexity: number
+  minPlayerCount: number
+  maxPlayerCount: number
+  bggPlaytimeMinutes: number
 }
 
-function ResultsTableRow({ alias, barcode, boardGameGeekThing, isCheckedOut, totalCheckedOutMinutes, checkOutCount }: ResultsRowProps) : JSX.Element {
+function ResultsTableRow({ 
+  bggId, libraryItemName, allCopiesCheckedOut, totalCheckedOutMinutes, totalCheckedOutEvents, bggAverageRating, bggAverageComplexity, minPlayerCount, maxPlayerCount, bggPlaytimeMinutes
+}: ResultsRowProps) : JSX.Element {
 
   return (
     <tr
-      key={barcode}
-      className={`${isCheckedOut ? 'italic text-red-400' : ''}`}
+      className={`${allCopiesCheckedOut ? 'italic text-red-400' : ''}`}
     >
-      <td className="p-3">{ alias || boardGameGeekThing.itemName }</td>
-      <td className="p-3">{ checkOutCount }</td>
+      <td className="p-3">{ libraryItemName }</td>
+      <td className="p-3">{ totalCheckedOutEvents }</td>
       <td className="p-3">{ totalCheckedOutMinutes } min</td>
-      <td className="p-3">{ Number(boardGameGeekThing.complexityRating).toFixed(1) }</td>
-      <td className="p-3">{ Number(boardGameGeekThing.averageUserRating).toFixed(1) }</td>
-      <td className="p-3">{ boardGameGeekThing.minimumPlayerCount }</td>
-      <td className="p-3">{ boardGameGeekThing.maximumPlayerCount }</td>
+      <td className="p-3">{ Number(bggAverageComplexity).toFixed(1) }</td>
+      <td className="p-3">{ Number(bggAverageRating).toFixed(1) }</td>
+      <td className="p-3">{ minPlayerCount }</td>
+      <td className="p-3">{ maxPlayerCount }</td>
+      <td className="p-3">{ bggPlaytimeMinutes }</td>
     </tr>
   )
 }

--- a/apps/admin/app/convention/(list)/convention-table.tsx
+++ b/apps/admin/app/convention/(list)/convention-table.tsx
@@ -7,10 +7,13 @@ import { DateTime } from 'ts-luxon'
 
 const ConventionStatus = (isCancelled: boolean, startDateTimeUtc?: string, endDateTimeUtc?: string) : string => {
   if (isCancelled) return 'Canceled'
-  if (!startDateTimeUtc) return 'Upcoming'
+  if (!startDateTimeUtc || !endDateTimeUtc) return 'Upcoming'
 
   const daysUntilStart = DateTime.fromISO(startDateTimeUtc).diff(DateTime.now(), 'days').days
-  const daysUntilEnd = DateTime.fromISO(startDateTimeUtc).diff(DateTime.now(), 'days').days
+  const daysUntilEnd = DateTime.fromISO(endDateTimeUtc).diff(DateTime.now(), 'days').days
+
+  console.log("until", daysUntilStart)
+  console.log("end", daysUntilEnd)
 
   if (daysUntilStart >= 0) return `${daysUntilStart.toFixed(0)} days from now`
   if (daysUntilStart <= 0 && daysUntilEnd >= 0) return "Happening"

--- a/apps/admin/app/scan/scanning-form.tsx
+++ b/apps/admin/app/scan/scanning-form.tsx
@@ -149,7 +149,7 @@ export default function ScanningTerminalClient() {
     <form onSubmit={handleSubmit(onSubmit)}>
 
       { fields.map(({ id }, index) => (
-        <div key={id} className="py-2 flex items-center">
+        <div key={index} className="py-2 flex items-center">
           <input
             className="w-full p-2 mr-2 border border-gray-300 rounded"
             placeholder="Enter or scan a barcode"

--- a/packages/shared/src/interfaces/top-checked-out-games.ts
+++ b/packages/shared/src/interfaces/top-checked-out-games.ts
@@ -1,15 +1,14 @@
-import { IBoardGameGeekEntity } from "@repo/board-game-geek-shared"
-
 interface TopCheckedOutGame {
-  alias: string
-  barcode: string
-  isCheckedOut: boolean
-  boardGameGeekThing: IBoardGameGeekEntity,
-  totalCheckedOutMinutes: number
-  _count: {
-    checkOutEvents: number;
-    // Add any other properties you expect in _count
-  };
+  bggId: number
+  libraryItemName: string
+  allCopiesCheckedOut: boolean
+  totalCheckedOutMinutes: string // bigint needs to be string
+  totalCheckedOutEvents: string // bigint needs to be string
+  bggAverageRating: number
+  bggAverageComplexity: number
+  minPlayerCount: number
+  maxPlayerCount: number
+  bggPlaytimeMinutes: number
 }
 
 export type { TopCheckedOutGame }

--- a/packages/tgd-database/prisma/docs/schema.dbml
+++ b/packages/tgd-database/prisma/docs/schema.dbml
@@ -29,7 +29,6 @@ Table conventions {
   playToWinGames play_to_win_items [not null]
   attendees attendees [not null]
   playToWinPlays play_to_win_plays [not null]
-  libraryCheckoutEvents library_checkout_events [not null]
 }
 
 Table venues {
@@ -156,8 +155,6 @@ Table library_checkout_events {
   library library_items [not null]
   attendeeId Int [not null]
   attendee attendees [not null]
-  conventionId Int
-  convention conventions
   checkedOutTimeUtcIso DateTime [not null]
   checkedInTimeUtcIso DateTime
 }
@@ -242,8 +239,6 @@ Ref: play_to_win_items.barcode > centralized_barcodes.barcode
 Ref: library_checkout_events.libraryCopyId > library_items.id
 
 Ref: library_checkout_events.attendeeId > attendees.id
-
-Ref: library_checkout_events.conventionId > conventions.id
 
 Ref: play_to_win_plays.playToWinItemId > play_to_win_items.id
 

--- a/packages/tgd-database/prisma/docs/schema.dbml
+++ b/packages/tgd-database/prisma/docs/schema.dbml
@@ -19,16 +19,17 @@ Table centralized_barcodes {
 Table conventions {
   id Int [pk, increment]
   name String [unique, not null]
-  extraHoursStartDateTimeUtc String
-  startDateTimeUtc String
-  endDateTimeUtc String
+  extraHoursStartDateTimeUtc DateTime
+  startDateTimeUtc DateTime
+  endDateTimeUtc DateTime
   updatedAtUtc String [not null]
   isCancelled Boolean [not null, default: false]
   venueId Int
   venue venues
-  PlayToWinGames play_to_win_items [not null]
-  Attendees attendees [not null]
-  PlayToWinPlays play_to_win_plays [not null]
+  playToWinGames play_to_win_items [not null]
+  attendees attendees [not null]
+  playToWinPlays play_to_win_plays [not null]
+  libraryCheckoutEvents library_checkout_events [not null]
 }
 
 Table venues {
@@ -94,8 +95,8 @@ Table library_items {
   isHidden Boolean [not null]
   isCheckedOut Boolean [not null]
   totalCheckedOutMinutes Int [not null, default: 0]
-  dateAddedUtc String [not null]
-  updatedAtUtc String [not null]
+  dateAddedUtc DateTime [not null]
+  updatedAtUtc DateTime [not null]
   checkOutEvents library_checkout_events [not null]
   additionalBoxContent library_item_contents [not null]
   centralizedBarcode centralized_barcodes [not null]
@@ -120,6 +121,7 @@ Table people {
   email String [unique]
   phoneNumber String [unique]
   zipCode String
+  dateAdded DateTime [default: `now()`, not null]
   emergencyContactName String
   emergencyContactPhoneNumber String
   emergencyContactRelationship String
@@ -143,7 +145,7 @@ Table play_to_win_items {
   convention conventions [not null]
   isHidden Boolean [not null]
   publisherName String
-  dateAddedUtc String [not null]
+  dateAddedUtc DateTime [not null]
   centralizedBarcode centralized_barcodes [not null]
   playToWinPlays play_to_win_plays [not null]
 }
@@ -154,15 +156,17 @@ Table library_checkout_events {
   library library_items [not null]
   attendeeId Int [not null]
   attendee attendees [not null]
-  checkedOutTimeUtcIso String [not null]
-  checkedInTimeUtcIso String
+  conventionId Int
+  convention conventions
+  checkedOutTimeUtcIso DateTime [not null]
+  checkedInTimeUtcIso DateTime
 }
 
 Table play_to_win_plays {
   id String [pk]
   playToWinItemId Int [not null]
   playToWinItem play_to_win_items [not null]
-  checkedInTimeUtcIso String [not null]
+  checkedInTimeUtcIso DateTime [not null]
   conventionId Int [not null]
   convention conventions [not null]
   playToWinPlayAttendees play_to_win_play_players [not null]
@@ -186,8 +190,8 @@ Table attendees {
   isStayingOnSite Boolean [not null, default: false]
   conventionId Int [not null]
   convention conventions [not null]
-  checkedInUtc String
-  dateRegistered String [not null]
+  checkedInUtc DateTime
+  dateRegistered DateTime [not null]
   isVolunteer Boolean [not null, default: false]
   idTgdOrganizer Boolean [not null, default: false]
   passPurchased PassTypePurchased [not null]
@@ -238,6 +242,8 @@ Ref: play_to_win_items.barcode > centralized_barcodes.barcode
 Ref: library_checkout_events.libraryCopyId > library_items.id
 
 Ref: library_checkout_events.attendeeId > attendees.id
+
+Ref: library_checkout_events.conventionId > conventions.id
 
 Ref: play_to_win_plays.playToWinItemId > play_to_win_items.id
 

--- a/packages/tgd-database/prisma/migrations/20240406211834_38_library_report_convention/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240406211834_38_library_report_convention/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "library_checkout_events" ADD COLUMN     "convention_id" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "library_checkout_events" ADD CONSTRAINT "library_checkout_events_convention_id_fkey" FOREIGN KEY ("convention_id") REFERENCES "conventions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/tgd-database/prisma/migrations/20240406214522_38_fix_dates_from_string/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240406214522_38_fix_dates_from_string/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `extra_hours_start_date_time_iso_utc` on the `conventions` table. All the data in the column will be lost.
+  - The `start_date_time_iso_utc` column on the `conventions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `end_date_time_iso_utc` column on the `conventions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `checked_in_time_utc` column on the `library_checkout_events` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `checked_out_time_utc` on the `library_checkout_events` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "conventions" DROP COLUMN "extra_hours_start_date_time_iso_utc",
+ADD COLUMN     "checked_out_time_utc" TEXT,
+DROP COLUMN "start_date_time_iso_utc",
+ADD COLUMN     "start_date_time_iso_utc" TIMESTAMPTZ,
+DROP COLUMN "end_date_time_iso_utc",
+ADD COLUMN     "end_date_time_iso_utc" TIMESTAMPTZ;
+
+-- AlterTable
+ALTER TABLE "library_checkout_events" DROP COLUMN "checked_out_time_utc",
+ADD COLUMN     "checked_out_time_utc" TIMESTAMPTZ NOT NULL,
+DROP COLUMN "checked_in_time_utc",
+ADD COLUMN     "checked_in_time_utc" TIMESTAMPTZ;

--- a/packages/tgd-database/prisma/migrations/20240406220236_38_fix_all_dates_from_string/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240406220236_38_fix_all_dates_from_string/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - The `checked_in_utc` column on the `attendees` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `checked_out_time_utc` column on the `conventions` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `registered_date_utc` on the `attendees` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `date_added_utc` on the `library_items` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `date_updated_utc` on the `library_items` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `date_added_utc` on the `play_to_win_items` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `checked_in_time_utc` on the `play_to_win_plays` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "attendees" DROP COLUMN "checked_in_utc",
+ADD COLUMN     "checked_in_utc" TIMESTAMPTZ,
+DROP COLUMN "registered_date_utc",
+ADD COLUMN     "registered_date_utc" TIMESTAMPTZ NOT NULL;
+
+-- AlterTable
+ALTER TABLE "conventions" DROP COLUMN "checked_out_time_utc",
+ADD COLUMN     "checked_out_time_utc" TIMESTAMPTZ;
+
+-- AlterTable
+ALTER TABLE "library_items" DROP COLUMN "date_added_utc",
+ADD COLUMN     "date_added_utc" TIMESTAMPTZ NOT NULL,
+DROP COLUMN "date_updated_utc",
+ADD COLUMN     "date_updated_utc" TIMESTAMPTZ NOT NULL;
+
+-- AlterTable
+ALTER TABLE "people" ADD COLUMN     "date_added_utc" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "play_to_win_items" DROP COLUMN "date_added_utc",
+ADD COLUMN     "date_added_utc" TIMESTAMPTZ NOT NULL;
+
+-- AlterTable
+ALTER TABLE "play_to_win_plays" DROP COLUMN "checked_in_time_utc",
+ADD COLUMN     "checked_in_time_utc" TIMESTAMPTZ NOT NULL;

--- a/packages/tgd-database/prisma/migrations/20240408174900_38_last_remaining_cleanup/migration.sql
+++ b/packages/tgd-database/prisma/migrations/20240408174900_38_last_remaining_cleanup/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `convention_id` on the `library_checkout_events` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "library_checkout_events" DROP CONSTRAINT "library_checkout_events_convention_id_fkey";
+
+-- AlterTable
+ALTER TABLE "library_checkout_events" DROP COLUMN "convention_id";

--- a/packages/tgd-database/prisma/schema.prisma
+++ b/packages/tgd-database/prisma/schema.prisma
@@ -45,17 +45,17 @@ enum EntityType {
 model Convention {
   id                         Int       @id @default(autoincrement()) @map(name: "id")
   name                       String    @unique @map(name: "name")
-  extraHoursStartDateTimeUtc String?   @map(name: "extra_hours_start_date_time_iso_utc")
-  startDateTimeUtc           String?   @map(name: "start_date_time_iso_utc")
-  endDateTimeUtc             String?   @map(name: "end_date_time_iso_utc")
+  extraHoursStartDateTimeUtc DateTime? @map(name: "checked_out_time_utc") @db.Timestamptz()
+  startDateTimeUtc           DateTime? @map(name: "start_date_time_iso_utc") @db.Timestamptz()
+  endDateTimeUtc             DateTime? @map(name: "end_date_time_iso_utc") @db.Timestamptz()
   updatedAtUtc               String    @map(name: "date_updated_utc")
   isCancelled                Boolean   @default(false) @map(name: "is_cancelled")
   venueId                    Int?      @map(name: "venue_id")
   venue                      Venue?    @relation(fields: [venueId], references: [id])
 
-  PlayToWinGames PlayToWinItem[]
-  Attendees      Attendee[]
-  PlayToWinPlays PlayToWinPlay[]  
+  playToWinGames        PlayToWinItem[]
+  attendees             Attendee[]
+  playToWinPlays        PlayToWinPlay[]
 
   @@map("conventions")
 }
@@ -134,8 +134,8 @@ model LibraryItem {
   isHidden               Boolean                        @map(name: "is_hidden")
   isCheckedOut           Boolean                        @map(name: "is_checked_out")
   totalCheckedOutMinutes Int                            @default(0) @map(name: "minutes_checked_out")
-  dateAddedUtc           String                         @map(name: "date_added_utc")
-  updatedAtUtc           String                         @map(name: "date_updated_utc")
+  dateAddedUtc           DateTime                       @map(name: "date_added_utc") @db.Timestamptz()
+  updatedAtUtc           DateTime                       @map(name: "date_updated_utc") @db.Timestamptz()
   checkOutEvents         LibraryCheckoutEvent[]
   additionalBoxContent   AdditionalLibraryItemContent[]
   centralizedBarcode     CentralizedBarcode             @relation(fields: [barcode], references: [barcode])
@@ -165,6 +165,7 @@ model Person {
   email                         String?    @map(name: "email")
   phoneNumber                   String?    @map(name: "phone_number")
   zipCode                       String?    @map(name: "zip_code")
+  dateAdded                     DateTime   @default(now()) @map(name: "date_added_utc") @db.Timestamptz()
 
   emergencyContactName          String?    @map(name: "emergency_contact_name")
   emergencyContactPhoneNumber   String?    @map(name: "emergency_contact_phone")
@@ -195,7 +196,7 @@ model PlayToWinItem {
   convention         Convention          @relation(fields: [conventionId], references: [id])
   isHidden           Boolean             @map(name: "is_hidden")
   publisherName      String?             @map(name: "publisher")
-  dateAddedUtc       String              @map(name: "date_added_utc")
+  dateAddedUtc       DateTime            @map(name: "date_added_utc") @db.Timestamptz()
   centralizedBarcode CentralizedBarcode  @relation(fields: [barcode], references: [barcode])
 
   playToWinPlays     PlayToWinPlay[]
@@ -211,8 +212,8 @@ model LibraryCheckoutEvent {
   library                   LibraryItem @relation(fields: [libraryCopyId], references: [id])
   attendeeId                Int         @map(name: "checkout_attendee_id")
   attendee                  Attendee    @relation(fields: [attendeeId], references: [id])
-  checkedOutTimeUtcIso      String      @map("checked_out_time_utc")
-  checkedInTimeUtcIso       String?     @map("checked_in_time_utc")
+  checkedOutTimeUtcIso      DateTime    @map("checked_out_time_utc") @db.Timestamptz()
+  checkedInTimeUtcIso       DateTime?   @map("checked_in_time_utc") @db.Timestamptz()
 
   @@map("library_checkout_events")
 }
@@ -221,7 +222,7 @@ model PlayToWinPlay {
   id                        String        @id @default(cuid()) @map(name: "id")
   playToWinItemId           Int           @map(name: "play_to_win_item_id")
   playToWinItem             PlayToWinItem @relation(fields: [playToWinItemId], references: [id])
-  checkedInTimeUtcIso       String        @map("checked_in_time_utc")
+  checkedInTimeUtcIso       DateTime      @map("checked_in_time_utc") @db.Timestamptz()
   conventionId              Int           @map("convention_id")
   convention                Convention    @relation(fields: [conventionId], references: [id])
 
@@ -250,8 +251,8 @@ model Attendee {
   isStayingOnSite    Boolean            @default(false) @map(name: "staying_at_convention")
   conventionId       Int                @map(name: "convention_id")
   convention         Convention         @relation(fields: [conventionId], references: [id])
-  checkedInUtc       String?            @map(name: "checked_in_utc")
-  dateRegistered     String             @map(name: "registered_date_utc")
+  checkedInUtc       DateTime?          @map(name: "checked_in_utc") @db.Timestamptz()
+  dateRegistered     DateTime           @map(name: "registered_date_utc") @db.Timestamptz()
   isVolunteer        Boolean            @default(false) @map(name: "is_volunteer")
   idTgdOrganizer     Boolean            @default(false) @map(name: "is_organizer")
   passPurchased      PassTypePurchased  @map(name: "pass_purchased")


### PR DESCRIPTION
## Completed

- Fix date in database for comparisons
- Build report for library games
- Add endpoint for library report per convention
- Add total check out times and minutes
- Fix Top 20 games report (multiple copies issue)

refs: #38

Endpoint: `/api/report/3/library`

closes: #38